### PR TITLE
Update Molecule verify to run role

### DIFF
--- a/molecule/default/verify.yml
+++ b/molecule/default/verify.yml
@@ -7,3 +7,13 @@
   tasks:
     - name: PING
       ansible.builtin.ping:
+
+    - name: Include author.template role
+      ansible.builtin.include_role:
+        name: author.template
+      register: role_result
+
+    - name: Verify role output
+      ansible.builtin.assert:
+        that:
+          - "'Ansible Role Template' in (role_result.results | map(attribute='msg') | join(' '))"


### PR DESCRIPTION
## Summary
- call the `author.template` role from verify playbook
- assert that the role output contains the template message

## Testing
- `ansible-playbook --syntax-check molecule/default/verify.yml` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683ff7fc71688323b1cf65d0f94e97c2