### PR TITLE
Fix role title and example role name in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-Role Name
-=========
+Template Role for Hetzner
+=========================
 
 A brief description of the role goes here.
 
@@ -25,7 +25,7 @@ Including an example of how to use your role (for instance, with variables passe
 
     - hosts: servers
       roles:
-         - { role: username.rolename, x: 42 }
+         - { role: author.template, x: 42 }
 
 License
 -------


### PR DESCRIPTION
## Summary
- update README with real role name
- use author.template in example

## Testing
- `ansible-lint --version` *(fails: command not found)*
- `molecule --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683ff7fbfbd08323b9db8087335ae1df