### PR TITLE
Fix SSH option variable names

### DIFF
--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -4,7 +4,7 @@
   become: true
   gather_facts: true
   vars:
-    ansible_ssh_common_args: " -F /tmp/ssh_config -o StrictHostKeychecking=no"
+    ansible_ssh_common_args: " -F /tmp/ssh_config -o StrictHostKeyChecking=no"
   pre_tasks:
     - name: Update Packages
       ansible.builtin.package:

--- a/molecule/default/create.yml
+++ b/molecule/default/create.yml
@@ -5,7 +5,7 @@
   vars_files:
     - ./vault.yml
   vars:
-    ansible_ssh_common_args: " -F /tmp/ssh_config -o StrictHostKeychecking=no"
+    ansible_ssh_common_args: " -F /tmp/ssh_config -o StrictHostKeyChecking=no"
   tasks:
     - name: Create test instances
       hetzner.hcloud.server:

--- a/molecule/default/destroy.yml
+++ b/molecule/default/destroy.yml
@@ -5,7 +5,7 @@
   vars_files:
     - ./vault.yml
   vars:
-    ansible_ssh_common_args: " -F /tmp/ssh_config -o StrictHostKeychecking=no"
+    ansible_ssh_common_args: " -F /tmp/ssh_config -o StrictHostKeyChecking=no"
   tasks:
     - name: Destroy test instances
       hetzner.hcloud.server:

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -32,7 +32,7 @@ provisioner:
     defaults:
       vault_password_file: "${MOLECULE_SCENARIO_DIRECTORY}/.vaultpass"
   connection_options:
-    ansible_ssh_common_args: " -F /tmp/ssh_config -o StrictHostKeychecking=no"
+    ansible_ssh_common_args: " -F /tmp/ssh_config -o StrictHostKeyChecking=no"
 lint: |
   set -e
   ansible-lint --exclude molecule/default/

--- a/molecule/default/verify.yml
+++ b/molecule/default/verify.yml
@@ -3,7 +3,7 @@
   hosts: all
   become: true
   vars:
-    ansible_ssh_common_args: " -F /tmp/ssh_config -o StrictHostKeychecking=no"
+    ansible_ssh_common_args: " -F /tmp/ssh_config -o StrictHostKeyChecking=no"
   tasks:
     - name: PING
       ansible.builtin.ping:


### PR DESCRIPTION
## Summary
- fix typo for StrictHostKeyChecking across molecule scenario files

## Testing
- `ansible-lint --version` *(fails: command not found)*
- `molecule --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683ff718495c83239841b568c76520db